### PR TITLE
fix: Fluentbit config default values on logCollection

### DIFF
--- a/modules/ecs_fargate/variables.tf
+++ b/modules/ecs_fargate/variables.tf
@@ -214,7 +214,17 @@ variable "dd_log_collection" {
           host_endpoint = "http-intake.logs.datadoghq.com"
         }
       )
-    }))
+      }),
+      {
+        fluentbit_config = {
+          registry      = "public.ecr.aws/aws-observability/aws-for-fluent-bit"
+          image_version = "stable"
+          log_driver_configuration = {
+            host_endpoint = "http-intake.logs.datadoghq.com"
+          }
+        }
+      }
+    )
   })
   default = {
     enabled = false


### PR DESCRIPTION
### What does this PR do?
<!--
A brief description of the change being made with this pull request.
-->

Provides default values for the fluentbit configuration when a user sets `logCollection.enabled`

### Motivation
<!--
What inspired you to submit this pull request?
-->

Provide easier onboarding experience. Allow default values to be set throughout all levels of the nested object.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* The PR description contains details of how you validated your changes.
-->

`terraform apply` with only the following configuration and verify that the host-endpoint is properly set

```
  dd_log_collection = {
    enabled = true,
  }
```

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Possible drawbacks and tradeoffs.
* Include info about alternatives that were considered and why the proposed version was chosen.
-->

For context, these values are already being set as the defaults but only if the user provides some value into `logCollection.fluentbitConfig`. [See here](https://github.com/DataDog/terraform-aws-ecs-datadog/pull/13/files#diff-58798bdf49a7574cd89c5c4575984a3a56b16add89a4efbfb912c49205eb14b7L183-L214)