### PR TITLE
fix: Add env, service, version tags to fluentbit and cws containers

### DIFF
--- a/modules/ecs_fargate/datadog.tf
+++ b/modules/ecs_fargate/datadog.tf
@@ -338,7 +338,7 @@ locals {
         memory_limit_mib = var.dd_log_collection.fluentbit_config.memory_limit_mib
         user             = "0"
         mountPoints      = []
-        environment      = []
+        environment      = local.ust_env_vars
         portMappings     = []
         systemControls   = []
         volumesFrom      = []
@@ -367,7 +367,7 @@ locals {
       entryPoint       = []
       command          = ["/cws-instrumentation", "setup", "--cws-volume-mount", "/cws-instrumentation-volume"]
       mountPoints      = local.cws_mount
-      environment      = []
+      environment      = local.ust_env_vars
       portMappings     = []
       systemControls   = []
       volumesFrom      = []


### PR DESCRIPTION
### What does this PR do?
<!--
A brief description of the change being made with this pull request.
-->

Adds the environment variables `DD_ENV`, `DD_SERVICE`, and `DD_VERSION` to the fluentbit log router and the cws init tracer.

### Motivation
<!--
What inspired you to submit this pull request?
-->

Parity experience with DatadogECSFargate CDK construct. The Agent is already receiving these tags and adding them onto the other Agent related containers completes the experience.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* The PR description contains details of how you validated your changes.
-->

`terraform apply` and check for the environment variables on the tracer and log router
```
  dd_log_collection = {
    enabled = true,
  }

  dd_cws = {
    enabled = true,
  }
```

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Possible drawbacks and tradeoffs.
* Include info about alternatives that were considered and why the proposed version was chosen.
-->