### PR TITLE
fix: Set `track_latest` on task resource

### DIFF
--- a/modules/ecs_fargate/main.tf
+++ b/modules/ecs_fargate/main.tf
@@ -158,6 +158,8 @@ resource "aws_ecs_task_definition" "this" {
     local.tags,
   )
 
+  track_latest = var.track_latest
+
   depends_on = [
     data.aws_iam_role.ecs_task_role,
     data.aws_iam_role.ecs_task_exec_role,
@@ -184,3 +186,4 @@ resource "aws_ecs_task_definition" "this" {
     }
   }
 }
+

--- a/smoke_tests/ecs_fargate/all-ecs-inputs.tf
+++ b/smoke_tests/ecs_fargate/all-ecs-inputs.tf
@@ -150,4 +150,5 @@ module "dd_task_all_ecs_inputs" {
     operating_system_family = "LINUX"
     cpu_architecture        = "X86_64"
   }
+  track_latest = false
 }

--- a/tests/all_ecs_inputs_test.go
+++ b/tests/all_ecs_inputs_test.go
@@ -23,6 +23,7 @@ func (s *ECSFargateSuite) TestAllECSInputs() {
 	s.Equal("512", task["memory"], "Unexpected memory value")
 	s.Equal("awsvpc", task["network_mode"], "Unexpected network mode")
 	s.Equal("task", task["pid_mode"], "Unexpected PID mode")
+	s.Equal("false", task["track_latest"], "Unexpected track_latest value")
 
 	s.Contains(task["ephemeral_storage"], "size_in_gib:40", "Unexpected ephemeral storage size")
 


### PR DESCRIPTION
### What does this PR do?

`track_latest` did not appear to be correctly set on the task resource. Set it and update tests to check,

### Motivation

Seems like the intented behavior.

### Describe how you validated your changes

Updated the unit and smoke_tests to include checks, however I can't run them locally. Let me know if it's not correct.

### Additional Notes

None seems pretty straight foward.
