### PR TITLE
feat: Expose Fluentbit Log Options

### DIFF
--- a/modules/ecs_fargate/datadog.tf
+++ b/modules/ecs_fargate/datadog.tf
@@ -340,9 +340,13 @@ locals {
         essential = var.dd_log_collection.fluentbit_config.is_log_router_essential
         firelensConfiguration = {
           type = "fluentbit"
-          options = {
-            enable-ecs-log-metadata = "true"
-          }
+          options = merge(
+            {
+              enable-ecs-log-metadata = "true"
+            },
+            try(var.dd_log_collection.fluentbit_config.firelens_options.config_file_type != null, false) ? { config-file-type = var.dd_log_collection.fluentbit_config.firelens_options.config_file_type } : {},
+            try(var.dd_log_collection.fluentbit_config.firelens_options.config_file_value != null, false) ? { config-file-value = var.dd_log_collection.fluentbit_config.firelens_options.config_file_value } : {} 
+          )
         }
         cpu              = var.dd_log_collection.fluentbit_config.cpu
         memory_limit_mib = var.dd_log_collection.fluentbit_config.memory_limit_mib

--- a/modules/ecs_fargate/variables.tf
+++ b/modules/ecs_fargate/variables.tf
@@ -204,6 +204,10 @@ variable "dd_log_collection" {
           timeout      = 5
         }
       )
+      firelens_options = optional(object({
+        config_file_type = optional(string)
+        config_file_value = optional(string)
+      }))
       log_driver_configuration = optional(object({
         host_endpoint = optional(string, "http-intake.logs.datadoghq.com")
         tls           = optional(bool)

--- a/smoke_tests/ecs_fargate/logging-only.tf
+++ b/smoke_tests/ecs_fargate/logging-only.tf
@@ -27,6 +27,10 @@ module "dd_task_logging_only" {
     enabled = true,
     fluentbit_config = {
       is_log_router_dependency_enabled = true,
+      firelens_options = {
+        config_file_type = "file"
+        config_file_value = "file:///fluent-bit/etc/fluent-bit.conf"
+      }
     }
   }
 

--- a/tests/logging_only_test.go
+++ b/tests/logging_only_test.go
@@ -104,6 +104,10 @@ func (s *ECSFargateSuite) TestLoggingOnly() {
 	s.Equal(types.FirelensConfigurationTypeFluentbit, logRouterContainer.FirelensConfiguration.Type, "Log router FireLens type should be fluentbit")
 	s.Equal("true", logRouterContainer.FirelensConfiguration.Options["enable-ecs-log-metadata"],
 		"Log router FireLens should have ECS log metadata enabled")
+	s.Equal("file", logRouterContainer.FirelensConfiguration.Options["config-file-type"],
+		"Log router FireLens should have config_file_type")
+	s.Equal("file:///fluent-bit/etc/fluent-bit.conf", logRouterContainer.FirelensConfiguration.Options["config-file-value"],
+		"Log router FireLens should have config_file_value")
 
 	// Verify no optional containers are present
 	_, found = GetContainer(containers, "cws-instrumentation-init")


### PR DESCRIPTION
### What does this PR do?
<!--
A brief description of the change being made with this pull request.
-->

Exposes `config-file-type` and `config-file-value` under the fluent bit log container's Firelens configuration options.

### Motivation
<!--
What inspired you to submit this pull request?
-->

Allow users to process logs with custom configurations. Particularly important for JSON logs.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* The PR description contains details of how you validated your changes.
-->

`aws-vault exec sso-xxxxx -- go test ./tests`
