### PR TITLE
chore: Prefix roles/policies with terraform-test

### DIFF
--- a/smoke_tests/ecs_fargate/all-ecs-inputs.tf
+++ b/smoke_tests/ecs_fargate/all-ecs-inputs.tf
@@ -32,7 +32,7 @@ resource "aws_efs_access_point" "fs" {
 }
 
 resource "aws_iam_role" "ecs_task_role" {
-  name = "terraform_test_ecs_task_role"
+  name = "terraform-test-ecs-task-role"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
@@ -49,7 +49,7 @@ resource "aws_iam_role" "ecs_task_role" {
 }
 
 resource "aws_iam_policy" "ecs_task_policy" {
-  name        = "terraform_test_ecs_task_policy"
+  name        = "terraform-test-ecs-task-policy"
   description = "Policy for ECS task role to access EFS"
   policy = jsonencode({
     Version = "2012-10-17"

--- a/smoke_tests/ecs_fargate/all-ecs-inputs.tf
+++ b/smoke_tests/ecs_fargate/all-ecs-inputs.tf
@@ -32,7 +32,7 @@ resource "aws_efs_access_point" "fs" {
 }
 
 resource "aws_iam_role" "ecs_task_role" {
-  name = "ecs_task_role"
+  name = "terraform_test_ecs_task_role"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
@@ -49,7 +49,7 @@ resource "aws_iam_role" "ecs_task_role" {
 }
 
 resource "aws_iam_policy" "ecs_task_policy" {
-  name        = "ecs_task_policy"
+  name        = "terraform_test_ecs_task_policy"
   description = "Policy for ECS task role to access EFS"
   policy = jsonencode({
     Version = "2012-10-17"


### PR DESCRIPTION
### What does this PR do?
<!--
A brief description of the change being made with this pull request.
-->

Prefixes resources created by the smoke tests for roles and policies to have the prefix "terraform-test"

### Motivation
<!--
What inspired you to submit this pull request?
-->

Able to easily scope down the permissions required for the terraform test commands to run so that all roles and policies created follow the same naming convention being prefixed with "terraform-test"

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* The PR description contains details of how you validated your changes.
-->

`make test`
