### PR TITLE
chore: Update v1.0.4 tags

### DIFF
--- a/modules/ecs_fargate/datadog.tf
+++ b/modules/ecs_fargate/datadog.tf
@@ -6,7 +6,7 @@
 # Version and Install Info
 locals {
   # Datadog ECS task tags
-  version = "1.0.3"
+  version = "1.0.4"
 
   install_info_tool              = "terraform"
   install_info_tool_version      = "terraform-aws-ecs-datadog"


### PR DESCRIPTION
### What does this PR do?
<!--
A brief description of the change being made with this pull request.
-->

Prepare new release for ECS Datadog Terraform module with fix for bumping the minimum AWS provider version to the actual minimum provider version.
