### PR TITLE
refactor: :recycle: pass in name of roles together with ARN, avoid data src

### DIFF
--- a/modules/ecs_fargate/README.md
+++ b/modules/ecs_fargate/README.md
@@ -160,11 +160,17 @@ resource "datadog_ecs_fargate_task" "example" {
     operating_system_family = "LINUX"
   }
 
-  # Instead of supplying the `task_role_arn` directly,
-  # provide it into the `arn` field of the `task_role` object.
+  # Instead of supplying the `task_role_arn` directly, provide the
+  # `arn` and `name` fields of the `task_role` object.
   task_role = {
-    arn = "arn:aws:iam::123456789012:role/my-example-role"
+    arn = "arn:aws:iam::123456789012:role/my-path/my-example-role"
+    name = "my-example-role"
   }
+  
+  # Alternatively, if the role is created in the same Terraform stack,
+  # provide the entire `aws_iam_role` block as the variable value.
+  # The `aws_iam_role` output meets the `arn` and `name` requirements.
+  execution_role = aws_iam_role.example_ecs_exec_role
 }
 ```
 

--- a/modules/ecs_fargate/iam.tf
+++ b/modules/ecs_fargate/iam.tf
@@ -39,14 +39,9 @@ resource "aws_iam_policy" "dd_secret_access" {
 # ==============================
 # Case 1: User provides existing Task Execution Role
 # ==============================
-data "aws_iam_role" "ecs_task_exec_role" {
-  count = local.edit_execution_role ? 1 : 0
-  name  = element(split("/", var.execution_role.arn), 1)
-}
-
 resource "aws_iam_role_policy_attachment" "existing_role_dd_secret" {
   count      = local.edit_execution_role ? 1 : 0
-  role       = data.aws_iam_role.ecs_task_exec_role[0].name
+  role       = var.execution_role.name
   policy_arn = aws_iam_policy.dd_secret_access[0].arn
 }
 
@@ -117,15 +112,10 @@ resource "aws_iam_policy" "dd_ecs_task_permissions" {
 # Case 1: User provides existing Task Role
 # ==============================
 
-data "aws_iam_role" "ecs_task_role" {
-  count = local.edit_task_role ? 1 : 0
-  name  = element(split("/", var.task_role.arn), 1)
-}
-
 # Always attach `dd_ecs_task_permissions`
 resource "aws_iam_role_policy_attachment" "existing_role_ecs_task_permissions" {
   count      = local.edit_task_role ? 1 : 0
-  role       = data.aws_iam_role.ecs_task_role[0].name
+  role       = var.task_role.name
   policy_arn = aws_iam_policy.dd_ecs_task_permissions.arn
 }
 

--- a/modules/ecs_fargate/main.tf
+++ b/modules/ecs_fargate/main.tf
@@ -161,8 +161,6 @@ resource "aws_ecs_task_definition" "this" {
   track_latest = var.track_latest
 
   depends_on = [
-    data.aws_iam_role.ecs_task_role,
-    data.aws_iam_role.ecs_task_exec_role,
     aws_iam_role.new_ecs_task_role,
     aws_iam_role.new_ecs_task_execution_role,
   ]

--- a/modules/ecs_fargate/variables.tf
+++ b/modules/ecs_fargate/variables.tf
@@ -313,12 +313,17 @@ variable "ephemeral_storage" {
 variable "execution_role" {
   description = "ARN of the task execution role that the Amazon ECS container agent and the Docker daemon can assume"
   type = object({
-    arn = string
+    arn  = string
+    name = string
   })
   default = null
   validation {
     condition     = var.execution_role == null || try(var.execution_role.arn != null, false)
     error_message = "If 'execution_role' is set, 'arn' must be a non-null string."
+  }
+  validation {
+    condition     = var.execution_role == null || try(var.execution_role.name != null, false)
+    error_message = "If 'execution_role' is set, 'name' must be a non-null string."
   }
 }
 
@@ -429,12 +434,17 @@ variable "tags" {
 variable "task_role" {
   description = "The ARN of the IAM role that allows your Amazon ECS container task to make calls to other AWS services"
   type = object({
-    arn = string
+    arn  = string
+    name = string
   })
   default = null
   validation {
     condition     = var.task_role == null || try(var.task_role.arn != null, false)
     error_message = "If 'task_role' is set, 'arn' must be a non-null string."
+  }
+  validation {
+    condition     = var.task_role == null || try(var.task_role.name != null, false)
+    error_message = "If 'task_role' is set, 'name' must be a non-null string."
   }
 }
 


### PR DESCRIPTION
### What does this PR do?
Refactors how the ECS Fargate module obtains and uses the name of the task role and task execution role, in order to avoid using a data source to lookup the role. This PR expects `name` to be passed together with `arn` in the `var.task_role` and `var.execution_role` variables, which are already defined as `object({})`. (Kudos to @gabedos for refactoring these variables this way in https://github.com/DataDog/terraform-aws-ecs-datadog/pull/11, paving the way for this PR.)

Implements #36.

### Motivation
I tried specifying a role with a path, and I got the error reported in #35.

The way the module is currently written, it is impossible to create the task role and/or task execution role adjacent to the module in the same Terraform stack. The data source does not find the role name at plan time, and so it never gets to apply to create the role.

The input for role ARN is already structured in such a way as to be compatible with passing in the entire `aws_iam_role` block, namely it already takes an object of type `{arn = string}` instead of a simple string. Someone has already done the pre-work for this PR in structuring the input in this manner. Most of the effort was to get users to stop passing in a simple string and instead pass in this object. Now that the module already takes in the object, it's simple to add `name` as an additional required attribute in the object. The attributes of an `aws_iam_role` block also contain a `name` element both in resource and data source form (in case someone uses their own data source to lookup the ARN of the role already to pass to this var). And even if users are crafting the object manually, adding the `name` string is intuitive and not overly burdensome.

### Describe how you validated your changes
I ran a `terraform apply` with success against a stack with the following IAM role and module definitions:

```hcl
resource "aws_iam_role" "foo" {
  path = "/my-chosen-path/"
  assume_role_policy = data.aws_iam_policy_document.ecs.json
}

module "test_pr37" {
  source = "git::https://github.com/erikpaasonen/terraform-aws-ecs-datadog.git//modules/ecs_fargate?ref=refactor/35/role-name"

  dd_api_key_secret = data.aws_secretsmanager_secret_version.dd_api_key
  task_role = aws_iam_role.foo
  family = "pr-37-test"
  container_definitions = jsonencode([
    {
      name : "my-container",
      image : "my-image:latest",
      mountPoints : [
        {
          "containerPath": "/mnt/data",
          "sourceVolume": "data-volume"
        },
        {
          "containerPath": "/mnt/config",
          "sourceVolume": "config-volume"
        }
      ]
    }
  ])
  volumes = [
    {
      name = "data-volume"
    },
    {
      name = "config-volume"
    }
  ]
  runtime_platform = {
    cpu_architecture        = "ARM64"
    operating_system_family = "LINUX"
  }
}
```

### Additional Notes

This is a mutually exclusive alternative to #39.