### PR TITLE
refactor: :recycle: parse role names correctly from ARN

### DIFF
--- a/modules/ecs_fargate/main.tf
+++ b/modules/ecs_fargate/main.tf
@@ -161,8 +161,6 @@ resource "aws_ecs_task_definition" "this" {
   track_latest = var.track_latest
 
   depends_on = [
-    data.aws_iam_role.ecs_task_role,
-    data.aws_iam_role.ecs_task_exec_role,
     aws_iam_role.new_ecs_task_role,
     aws_iam_role.new_ecs_task_execution_role,
   ]


### PR DESCRIPTION
### What does this PR do?
Avoids the data source to lookup the name of the role whose ARN is provided in a variable. Instead, parse the name from the ARN. The role may have an arbitrary quantity of additional slash characters. This PR splits by the slash character and takes the final element, ensuring that the actual role name (regardless of the path) is parsed.

### Motivation
I tried specifying a role with a path, and I got the error reported in #35.

### Describe how you validated your changes
I ran `terraform apply` with success using the following IAM role and module definitions:

```hcl
resource "aws_iam_role" "foo" {
  path = "/my-chosen-path/"
  assume_role_policy = data.aws_iam_policy_document.ecs.json
}

module "test_pr39" {
  source = "git::https://github.com/erikpaasonen/terraform-aws-ecs-datadog.git//modules/ecs_fargate?ref=parse-role-name-from-arn"

  dd_api_key_secret = data.aws_secretsmanager_secret_version.dd_api_key
  task_role = aws_iam_role.foo
  family = "pr-39-test"
  container_definitions = jsonencode([
    {
      name : "my-container",
      image : "my-image:latest",
      mountPoints : [
        {
          "containerPath": "/mnt/data",
          "sourceVolume": "data-volume"
        },
        {
          "containerPath": "/mnt/config",
          "sourceVolume": "config-volume"
        }
      ]
    }
  ])
  volumes = [
    {
      name = "data-volume"
    },
    {
      name = "config-volume"
    }
  ]
  runtime_platform = {
    cpu_architecture        = "ARM64"
    operating_system_family = "LINUX"
  }
}
```

### Additional Notes

This is a mutually exclusive alternative to #37.

AWS does publish a little-known [function](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/functions/arn_parse) with its Terraform provider which parses ARNs correctly. Unfortunately, it does not distinguish between path and name for IAM role ARNs. So using it instead of the native HCL doesn't buy anything for the added complexity.
