### PR TITLE
fix(ecs_fargate): 🐛 fix defect in parsing role name from ARN, avoid data src

### DIFF
--- a/modules/ecs_fargate/main.tf
+++ b/modules/ecs_fargate/main.tf
@@ -161,8 +161,6 @@ resource "aws_ecs_task_definition" "this" {
   track_latest = var.track_latest
 
   depends_on = [
-    data.aws_iam_role.ecs_task_role,
-    data.aws_iam_role.ecs_task_exec_role,
     aws_iam_role.new_ecs_task_role,
     aws_iam_role.new_ecs_task_execution_role,
   ]


### PR DESCRIPTION
### What does this PR do?
- Fixes a defect in the ECS Fargate module in how the name of a role is parsed
- Refactors away from data source lookups against the names of the roles, consuming the parsed role name

### Motivation
I tried specifying a role with a path, and I got the error reported in #35.

Valid role ARNs may have a nearly-arbitrary quantity of slash characters depending on whether it was created with a `path`. This PR takes the final element from having split the ARN by the slash character, ensuring that the actual role name (regardless of the path) is parsed.

The data source lookup on the name of the role causes an implied requirement that the role already exists at plan time. This effectively prohibits users from creating the role using an `aws_iam_role` adjacent to this module call in the same Terraform stack, since the name of the role is an attribute available only at apply time (such as when `name_prefix` is specified in `aws_iam_role`). This PR removes the implied prohibition by removing the data source.

### Describe how you validated your changes
I ran `terraform apply` with success using the following IAM role and module definitions:

```hcl
resource "aws_iam_role" "foo" {
  path = "/my-chosen-path/"
  assume_role_policy = data.aws_iam_policy_document.ecs.json
}

module "test_pr39" {
  source = "git::https://github.com/erikpaasonen/terraform-aws-ecs-datadog.git//modules/ecs_fargate?ref=refactor/35/parse-role-name-from-arn"

  dd_api_key_secret = data.aws_secretsmanager_secret_version.dd_api_key
  task_role = aws_iam_role.foo
  family = "pr-39-test"
  container_definitions = jsonencode([
    {
      name : "my-container",
      image : "my-image:latest",
      mountPoints : [
        {
          "containerPath": "/mnt/data",
          "sourceVolume": "data-volume"
        },
        {
          "containerPath": "/mnt/config",
          "sourceVolume": "config-volume"
        }
      ]
    }
  ])
  volumes = [
    {
      name = "data-volume"
    },
    {
      name = "config-volume"
    }
  ]
  runtime_platform = {
    cpu_architecture        = "ARM64"
    operating_system_family = "LINUX"
  }
}
```

### Additional Notes

This is a mutually exclusive alternative to #37.

AWS does publish a little-known [function](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/functions/arn_parse) with its Terraform provider which parses ARNs correctly. Unfortunately, it does not distinguish between path and name for IAM role ARNs. So using it instead of the native HCL doesn't buy anything for the added complexity.
