### PR TITLE
[CONTP-951] Support env vars passed down to dd logging container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ target
 bin
 obj
 .DS_Store
+
+# Jetbrains
+.idea

--- a/examples/ecs_fargate/README.md
+++ b/examples/ecs_fargate/README.md
@@ -9,6 +9,7 @@ This example showcases a simple ECS Fargate Task Definition with out of the box 
   * Set the `dd_api_key` to the Datadog API Key (required)
   * Set the `dd_service` to the name of the service you want to use to filter for the resource in Datadog
   * Set the `dd_site` to the [Datadog destination site](https://docs.datadoghq.com/getting_started/site/) for your metrics, traces, and logs
+  * (Optional) Set `task_family_name` to the name of the task family (default: "datadog-terraform-app")
 * Run the following commands:
 
 ```bash

--- a/examples/ecs_fargate/main.tf
+++ b/examples/ecs_fargate/main.tf
@@ -45,7 +45,7 @@ module "datadog_ecs_fargate_task" {
   }
 
   # Configure Task Definition
-  family = "dummy-terraform-app"
+  family = var.task_family_name
   container_definitions = jsonencode([
     {
       name      = "dummy-dogstatsd-app",

--- a/examples/ecs_fargate/variables.tf
+++ b/examples/ecs_fargate/variables.tf
@@ -26,3 +26,9 @@ variable "dd_site" {
   type        = string
   default     = "datadoghq.com"
 }
+
+variable "task_family_name" {
+  description = "The ECS task family name"
+  type        = string
+  default     = "dummy-terraform-app"
+}

--- a/modules/ecs_fargate/datadog.tf
+++ b/modules/ecs_fargate/datadog.tf
@@ -338,6 +338,11 @@ locals {
     )
   ]
 
+  dd_log_agent_env = concat(
+    local.ust_env_vars,
+    var.dd_log_collection.fluentbit_config.environment
+  )
+
   # Datadog log router container definition
   dd_log_container = local.is_fluentbit_supported ? [
     merge(
@@ -359,7 +364,7 @@ locals {
         memory_limit_mib = var.dd_log_collection.fluentbit_config.memory_limit_mib
         user             = "0"
         mountPoints      = []
-        environment      = local.ust_env_vars
+        environment      = local.dd_log_agent_env
         portMappings     = []
         systemControls   = []
         volumesFrom      = []

--- a/modules/ecs_fargate/variables.tf
+++ b/modules/ecs_fargate/variables.tf
@@ -191,6 +191,7 @@ variable "dd_log_collection" {
       memory_limit_mib                 = optional(number)
       is_log_router_essential          = optional(bool, false)
       is_log_router_dependency_enabled = optional(bool, false)
+      environment                      = optional(list(map(string)), [{}])
       log_router_health_check = optional(object({
         command      = optional(list(string))
         interval     = optional(number)

--- a/smoke_tests/ecs_fargate/logging-only.tf
+++ b/smoke_tests/ecs_fargate/logging-only.tf
@@ -31,6 +31,12 @@ module "dd_task_logging_only" {
         config_file_type  = "file"
         config_file_value = "file:///fluent-bit/etc/fluent-bit.conf"
       }
+      environment = [
+        {
+          name  = "DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL"
+          value = "true"
+        }
+      ]
     }
   }
 

--- a/tests/logging_only_test.go
+++ b/tests/logging_only_test.go
@@ -87,7 +87,8 @@ func (s *ECSFargateSuite) TestLoggingOnly() {
 
 	// Verify log router environment variables
 	expectedLogRouterEnvVars := map[string]string{
-		"DD_SERVICE": "test-service",
+		"DD_SERVICE":                           "test-service",
+		"DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL": "true",
 	}
 	AssertEnvVars(s.T(), logRouterContainer, expectedLogRouterEnvVars)
 


### PR DESCRIPTION
### What does this PR do?
<!--
A brief description of the change being made with this pull request.
-->

### Motivation

A customer requested the ability to configure log router level environment variables in addition to the datadog agent. Currently, only the agent can be configured with `dd_environment` so this PR adds a similar option to `dd_log_collection`

### Describe how you validated your changes

1. Updated `logging_only_test.go` test to validate env vars passed to `dd_log_collection.fluentbit_config.environment` are passed down to the container task def.
2. Manually QAd by provisioning an ecs fargate task with an added environment var in the `dd_log_collection` then confirmed the env var is found in the task def on aws console.
 

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Possible drawbacks and tradeoffs.
* Include info about alternatives that were considered and why the proposed version was chosen.
-->
