### PR TITLE
[CONTP-962] Add tests for IAM role names with paths.

### DIFF
--- a/smoke_tests/ecs_fargate/outputs.tf
+++ b/smoke_tests/ecs_fargate/outputs.tf
@@ -29,3 +29,11 @@ output "cws-only" {
 output "logging-only" {
   value = module.dd_task_logging_only
 }
+
+output "role-parsing-with-path" {
+  value = module.dd_task_role_parsing_with_path
+}
+
+output "role-parsing-without-path" {
+  value = module.dd_task_role_parsing_without_path
+}

--- a/smoke_tests/ecs_fargate/role-parsing-with-path.tf
+++ b/smoke_tests/ecs_fargate/role-parsing-with-path.tf
@@ -12,7 +12,7 @@
 # Create IAM roles with paths to test the parsing logic
 resource "aws_iam_role" "test_task_role_with_path" {
   name = "${var.test_prefix}-task-role-with-path"
-  path = "/test-task-path/"
+  path = "/terraform-test/"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
@@ -28,7 +28,7 @@ resource "aws_iam_role" "test_task_role_with_path" {
 
 resource "aws_iam_role" "test_execution_role_with_path" {
   name = "${var.test_prefix}-execution-role-with-path"
-  path = "/test-execution-path/"
+  path = "/terraform-test/"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"

--- a/smoke_tests/ecs_fargate/role-parsing-with-path.tf
+++ b/smoke_tests/ecs_fargate/role-parsing-with-path.tf
@@ -61,7 +61,7 @@ module "dd_task_role_parsing_with_path" {
   dd_essential = true
 
   # Configure Task Definition
-  family = "${var.test_prefix}-role-parsing-with-path"
+  family                = "${var.test_prefix}-role-parsing-with-path"
   container_definitions = jsonencode([])
 
   requires_compatibilities = ["FARGATE"]

--- a/smoke_tests/ecs_fargate/role-parsing-with-path.tf
+++ b/smoke_tests/ecs_fargate/role-parsing-with-path.tf
@@ -12,7 +12,7 @@
 # Create IAM roles with paths to test the parsing logic
 resource "aws_iam_role" "test_task_role_with_path" {
   name = "${var.test_prefix}-task-role-with-path"
-  path = "/test-path/"
+  path = "/test-task-path/"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"

--- a/smoke_tests/ecs_fargate/role-parsing-with-path.tf
+++ b/smoke_tests/ecs_fargate/role-parsing-with-path.tf
@@ -1,0 +1,74 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2025-present Datadog, Inc.
+
+################################################################################
+# Test: Role ARN parsing with path
+# This test verifies that the module correctly parses role names from ARNs
+# that include paths (e.g., /my-path/role-name)
+################################################################################
+
+# Create IAM roles with paths to test the parsing logic
+resource "aws_iam_role" "test_task_role_with_path" {
+  name = "${var.test_prefix}-task-role-with-path"
+  path = "/test-path/"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Service = "ecs-tasks.amazonaws.com"
+      }
+      Action = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role" "test_execution_role_with_path" {
+  name = "${var.test_prefix}-execution-role-with-path"
+  path = "/test-execution-path/"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Service = "ecs-tasks.amazonaws.com"
+      }
+      Action = "sts:AssumeRole"
+    }]
+  })
+}
+
+# Attach required policies to execution role
+resource "aws_iam_role_policy_attachment" "test_execution_role_policy" {
+  role       = aws_iam_role.test_execution_role_with_path.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+module "dd_task_role_parsing_with_path" {
+  source = "../../modules/ecs_fargate"
+
+  # Use roles with paths to test parsing
+  task_role      = aws_iam_role.test_task_role_with_path
+  execution_role = aws_iam_role.test_execution_role_with_path
+
+  dd_api_key   = var.dd_api_key
+  dd_site      = var.dd_site
+  dd_service   = var.dd_service
+  dd_essential = true
+
+  # Configure Task Definition
+  family = "${var.test_prefix}-role-parsing-with-path"
+  container_definitions = jsonencode([
+    {
+      name      = "test-app",
+      image     = "nginx:latest",
+      essential = true,
+    }
+  ])
+
+  requires_compatibilities = ["FARGATE"]
+}

--- a/smoke_tests/ecs_fargate/role-parsing-with-path.tf
+++ b/smoke_tests/ecs_fargate/role-parsing-with-path.tf
@@ -53,7 +53,7 @@ module "dd_task_role_parsing_with_path" {
 
   # Use roles with paths to test parsing
   task_role      = aws_iam_role.test_task_role_with_path
-  execution_role = aws_iam_role.test_execution_role_with_path
+  execution_role = { arn = aws_iam_role.test_execution_role_with_path.arn }
 
   dd_api_key   = var.dd_api_key
   dd_site      = var.dd_site
@@ -62,13 +62,7 @@ module "dd_task_role_parsing_with_path" {
 
   # Configure Task Definition
   family = "${var.test_prefix}-role-parsing-with-path"
-  container_definitions = jsonencode([
-    {
-      name      = "test-app",
-      image     = "nginx:latest",
-      essential = true,
-    }
-  ])
+  container_definitions = jsonencode([])
 
   requires_compatibilities = ["FARGATE"]
 }

--- a/smoke_tests/ecs_fargate/role-parsing-with-path.tf
+++ b/smoke_tests/ecs_fargate/role-parsing-with-path.tf
@@ -4,9 +4,7 @@
 # Copyright 2025-present Datadog, Inc.
 
 ################################################################################
-# Test: Role ARN parsing with path
-# This test verifies that the module correctly parses role names from ARNs
-# that include paths (e.g., /my-path/role-name)
+# Task Definition: IAM Role with path in name
 ################################################################################
 
 # Create IAM roles with paths to test the parsing logic

--- a/smoke_tests/ecs_fargate/role-parsing-without-path.tf
+++ b/smoke_tests/ecs_fargate/role-parsing-without-path.tf
@@ -53,7 +53,7 @@ module "dd_task_role_parsing_without_path" {
 
   # Use roles without paths to test parsing
   task_role      = aws_iam_role.test_task_role_without_path
-  execution_role = aws_iam_role.test_execution_role_without_path
+  execution_role = { arn = aws_iam_role.test_execution_role_without_path.arn }
 
   dd_api_key   = var.dd_api_key
   dd_site      = var.dd_site
@@ -62,13 +62,7 @@ module "dd_task_role_parsing_without_path" {
 
   # Configure Task Definition
   family = "${var.test_prefix}-role-parsing-without-path"
-  container_definitions = jsonencode([
-    {
-      name      = "test-app",
-      image     = "nginx:latest",
-      essential = true,
-    }
-  ])
+  container_definitions = jsonencode([])
 
   requires_compatibilities = ["FARGATE"]
 }

--- a/smoke_tests/ecs_fargate/role-parsing-without-path.tf
+++ b/smoke_tests/ecs_fargate/role-parsing-without-path.tf
@@ -4,9 +4,7 @@
 # Copyright 2025-present Datadog, Inc.
 
 ################################################################################
-# Test: Role ARN parsing without path
-# This test verifies that the module correctly parses role names from ARNs
-# that do NOT include paths (e.g., role-name directly)
+# Task Definition: IAM Role without path in name
 ################################################################################
 
 # Create IAM roles without paths to test the parsing logic

--- a/smoke_tests/ecs_fargate/role-parsing-without-path.tf
+++ b/smoke_tests/ecs_fargate/role-parsing-without-path.tf
@@ -61,7 +61,7 @@ module "dd_task_role_parsing_without_path" {
   dd_essential = true
 
   # Configure Task Definition
-  family = "${var.test_prefix}-role-parsing-without-path"
+  family                = "${var.test_prefix}-role-parsing-without-path"
   container_definitions = jsonencode([])
 
   requires_compatibilities = ["FARGATE"]

--- a/smoke_tests/ecs_fargate/role-parsing-without-path.tf
+++ b/smoke_tests/ecs_fargate/role-parsing-without-path.tf
@@ -1,0 +1,74 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2025-present Datadog, Inc.
+
+################################################################################
+# Test: Role ARN parsing without path
+# This test verifies that the module correctly parses role names from ARNs
+# that do NOT include paths (e.g., role-name directly)
+################################################################################
+
+# Create IAM roles without paths to test the parsing logic
+resource "aws_iam_role" "test_task_role_without_path" {
+  name = "${var.test_prefix}-task-role-without-path"
+  # No path specified - defaults to "/"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Service = "ecs-tasks.amazonaws.com"
+      }
+      Action = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role" "test_execution_role_without_path" {
+  name = "${var.test_prefix}-execution-role-without-path"
+  # No path specified - defaults to "/"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Service = "ecs-tasks.amazonaws.com"
+      }
+      Action = "sts:AssumeRole"
+    }]
+  })
+}
+
+# Attach required policies to execution role
+resource "aws_iam_role_policy_attachment" "test_execution_role_policy_no_path" {
+  role       = aws_iam_role.test_execution_role_without_path.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+module "dd_task_role_parsing_without_path" {
+  source = "../../modules/ecs_fargate"
+
+  # Use roles without paths to test parsing
+  task_role      = aws_iam_role.test_task_role_without_path
+  execution_role = aws_iam_role.test_execution_role_without_path
+
+  dd_api_key   = var.dd_api_key
+  dd_site      = var.dd_site
+  dd_service   = var.dd_service
+  dd_essential = true
+
+  # Configure Task Definition
+  family = "${var.test_prefix}-role-parsing-without-path"
+  container_definitions = jsonencode([
+    {
+      name      = "test-app",
+      image     = "nginx:latest",
+      essential = true,
+    }
+  ])
+
+  requires_compatibilities = ["FARGATE"]
+}

--- a/tests/role_parsing_test.go
+++ b/tests/role_parsing_test.go
@@ -31,7 +31,7 @@ func (s *ECSFargateSuite) TestRoleParsingWithPath() {
 
 	taskRoleArn := task["task_role_arn"]
 	s.NotEmpty(taskRoleArn, "Task role ARN should not be empty")
-	s.Contains(taskRoleArn, "/test-path/", "Task role ARN should contain the path '/test-path/'")
+	s.Contains(taskRoleArn, "/test-task-path/", "Task role ARN should contain the path '/test-path/'")
 	s.Contains(taskRoleArn, s.testPrefix+"-task-role-with-path", "Task role ARN should contain the expected role name")
 
 	executionRoleArn := task["execution_role_arn"]

--- a/tests/role_parsing_test.go
+++ b/tests/role_parsing_test.go
@@ -1,0 +1,110 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package test
+
+import (
+	"encoding/json"
+	"log"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
+	"github.com/gruntwork-io/terratest/modules/terraform"
+)
+
+// TestRoleParsingWithPath tests that the module correctly parses role names from ARNs with paths
+func (s *ECSFargateSuite) TestRoleParsingWithPath() {
+	log.Println("TestRoleParsingWithPath: Running test...")
+
+	// Retrieve the task output for the "role-parsing-with-path" module
+	var containers []types.ContainerDefinition
+	task := terraform.OutputMap(s.T(), s.terraformOptions, "role-parsing-with-path")
+
+	s.Equal(s.testPrefix+"-role-parsing-with-path", task["family"], "Unexpected task family name")
+
+	err := json.Unmarshal([]byte(task["container_definitions"]), &containers)
+	s.NoError(err, "Failed to parse container definitions")
+
+	// Verify that the task was created successfully (which means role parsing worked)
+	s.NotEmpty(task["arn"], "Task definition ARN should not be empty")
+	s.NotEmpty(task["revision"], "Task definition revision should not be empty")
+
+	// Verify the task role ARN contains the expected path
+	taskRoleArn := task["task_role_arn"]
+	s.NotEmpty(taskRoleArn, "Task role ARN should not be empty")
+	s.Contains(taskRoleArn, "/test-path/", "Task role ARN should contain the path '/test-path/'")
+	s.Contains(taskRoleArn, s.testPrefix+"-task-role-with-path", "Task role ARN should contain the expected role name")
+
+	// Verify the execution role ARN contains the expected path
+	executionRoleArn := task["execution_role_arn"]
+	s.NotEmpty(executionRoleArn, "Execution role ARN should not be empty")
+	s.Contains(executionRoleArn, "/test-execution-path/", "Execution role ARN should contain the path '/test-execution-path/'")
+	s.Contains(executionRoleArn, s.testPrefix+"-execution-role-with-path", "Execution role ARN should contain the expected role name")
+
+	// Test Agent Container exists and is configured
+	agentContainer, found := GetContainer(containers, "datadog-agent")
+	s.True(found, "Container datadog-agent not found in definitions")
+	s.NotNil(agentContainer.Image, "Agent container image should not be nil")
+
+	// Test application container exists
+	appContainer, found := GetContainer(containers, "test-app")
+	s.True(found, "Container test-app not found in definitions")
+	s.Equal("nginx:latest", *appContainer.Image, "Unexpected image for test-app")
+
+	log.Println("TestRoleParsingWithPath: Role parsing with path test completed successfully")
+}
+
+// TestRoleParsingWithoutPath tests that the module correctly parses role names from ARNs without paths
+func (s *ECSFargateSuite) TestRoleParsingWithoutPath() {
+	log.Println("TestRoleParsingWithoutPath: Running test...")
+
+	// Retrieve the task output for the "role-parsing-without-path" module
+	var containers []types.ContainerDefinition
+	task := terraform.OutputMap(s.T(), s.terraformOptions, "role-parsing-without-path")
+
+	s.Equal(s.testPrefix+"-role-parsing-without-path", task["family"], "Unexpected task family name")
+
+	err := json.Unmarshal([]byte(task["container_definitions"]), &containers)
+	s.NoError(err, "Failed to parse container definitions")
+
+	// Verify that the task was created successfully (which means role parsing worked)
+	s.NotEmpty(task["arn"], "Task definition ARN should not be empty")
+	s.NotEmpty(task["revision"], "Task definition revision should not be empty")
+
+	// Verify the task role ARN does NOT contain additional paths (should be at root)
+	taskRoleArn := task["task_role_arn"]
+	s.NotEmpty(taskRoleArn, "Task role ARN should not be empty")
+	s.Contains(taskRoleArn, s.testPrefix+"-task-role-without-path", "Task role ARN should contain the expected role name")
+
+	// For roles without explicit paths, AWS defaults to "/" so the ARN format should be:
+	// arn:aws:iam::account:role/role-name (not arn:aws:iam::account:role/path/role-name)
+	roleArnParts := strings.Split(taskRoleArn, "/")
+	s.Equal(2, len(roleArnParts), "Role ARN without path should have exactly 2 parts when split by '/'")
+	s.Contains(roleArnParts[1], s.testPrefix+"-task-role-without-path", "Role name should be the second part after splitting by '/'")
+
+	// Verify the execution role ARN does NOT contain additional paths
+	executionRoleArn := task["execution_role_arn"]
+	s.NotEmpty(executionRoleArn, "Execution role ARN should not be empty")
+	s.Contains(executionRoleArn, s.testPrefix+"-execution-role-without-path", "Execution role ARN should contain the expected role name")
+
+	execRoleArnParts := strings.Split(executionRoleArn, "/")
+	s.Equal(2, len(execRoleArnParts), "Execution role ARN without path should have exactly 2 parts when split by '/'")
+	s.Contains(execRoleArnParts[1], s.testPrefix+"-execution-role-without-path", "Execution role name should be the second part after splitting by '/'")
+
+	// Test that containers are properly configured
+	s.GreaterOrEqual(len(containers), 2, "Expected at least 2 containers (datadog-agent + test-app)")
+
+	// Test Agent Container exists and is configured
+	agentContainer, found := GetContainer(containers, "datadog-agent")
+	s.True(found, "Container datadog-agent not found in definitions")
+	s.NotNil(agentContainer.Image, "Agent container image should not be nil")
+
+	// Test application container exists
+	appContainer, found := GetContainer(containers, "test-app")
+	s.True(found, "Container test-app not found in definitions")
+	s.Equal("nginx:latest", *appContainer.Image, "Unexpected image for test-app")
+
+	log.Println("TestRoleParsingWithoutPath: Role parsing without path test completed successfully")
+}

--- a/tests/role_parsing_test.go
+++ b/tests/role_parsing_test.go
@@ -18,7 +18,6 @@ import (
 func (s *ECSFargateSuite) TestRoleParsingWithPath() {
 	log.Println("TestRoleParsingWithPath: Running test...")
 
-	// Retrieve the task output for the "role-parsing-with-path" module
 	var containers []types.ContainerDefinition
 	task := terraform.OutputMap(s.T(), s.terraformOptions, "role-parsing-with-path")
 
@@ -27,40 +26,24 @@ func (s *ECSFargateSuite) TestRoleParsingWithPath() {
 	err := json.Unmarshal([]byte(task["container_definitions"]), &containers)
 	s.NoError(err, "Failed to parse container definitions")
 
-	// Verify that the task was created successfully (which means role parsing worked)
 	s.NotEmpty(task["arn"], "Task definition ARN should not be empty")
 	s.NotEmpty(task["revision"], "Task definition revision should not be empty")
 
-	// Verify the task role ARN contains the expected path
 	taskRoleArn := task["task_role_arn"]
 	s.NotEmpty(taskRoleArn, "Task role ARN should not be empty")
 	s.Contains(taskRoleArn, "/test-path/", "Task role ARN should contain the path '/test-path/'")
 	s.Contains(taskRoleArn, s.testPrefix+"-task-role-with-path", "Task role ARN should contain the expected role name")
 
-	// Verify the execution role ARN contains the expected path
 	executionRoleArn := task["execution_role_arn"]
 	s.NotEmpty(executionRoleArn, "Execution role ARN should not be empty")
 	s.Contains(executionRoleArn, "/test-execution-path/", "Execution role ARN should contain the path '/test-execution-path/'")
 	s.Contains(executionRoleArn, s.testPrefix+"-execution-role-with-path", "Execution role ARN should contain the expected role name")
-
-	// Test Agent Container exists and is configured
-	agentContainer, found := GetContainer(containers, "datadog-agent")
-	s.True(found, "Container datadog-agent not found in definitions")
-	s.NotNil(agentContainer.Image, "Agent container image should not be nil")
-
-	// Test application container exists
-	appContainer, found := GetContainer(containers, "test-app")
-	s.True(found, "Container test-app not found in definitions")
-	s.Equal("nginx:latest", *appContainer.Image, "Unexpected image for test-app")
-
-	log.Println("TestRoleParsingWithPath: Role parsing with path test completed successfully")
 }
 
 // TestRoleParsingWithoutPath tests that the module correctly parses role names from ARNs without paths
 func (s *ECSFargateSuite) TestRoleParsingWithoutPath() {
 	log.Println("TestRoleParsingWithoutPath: Running test...")
 
-	// Retrieve the task output for the "role-parsing-without-path" module
 	var containers []types.ContainerDefinition
 	task := terraform.OutputMap(s.T(), s.terraformOptions, "role-parsing-without-path")
 
@@ -69,22 +52,17 @@ func (s *ECSFargateSuite) TestRoleParsingWithoutPath() {
 	err := json.Unmarshal([]byte(task["container_definitions"]), &containers)
 	s.NoError(err, "Failed to parse container definitions")
 
-	// Verify that the task was created successfully (which means role parsing worked)
 	s.NotEmpty(task["arn"], "Task definition ARN should not be empty")
 	s.NotEmpty(task["revision"], "Task definition revision should not be empty")
 
-	// Verify the task role ARN does NOT contain additional paths (should be at root)
 	taskRoleArn := task["task_role_arn"]
 	s.NotEmpty(taskRoleArn, "Task role ARN should not be empty")
 	s.Contains(taskRoleArn, s.testPrefix+"-task-role-without-path", "Task role ARN should contain the expected role name")
 
-	// For roles without explicit paths, AWS defaults to "/" so the ARN format should be:
-	// arn:aws:iam::account:role/role-name (not arn:aws:iam::account:role/path/role-name)
 	roleArnParts := strings.Split(taskRoleArn, "/")
 	s.Equal(2, len(roleArnParts), "Role ARN without path should have exactly 2 parts when split by '/'")
 	s.Contains(roleArnParts[1], s.testPrefix+"-task-role-without-path", "Role name should be the second part after splitting by '/'")
 
-	// Verify the execution role ARN does NOT contain additional paths
 	executionRoleArn := task["execution_role_arn"]
 	s.NotEmpty(executionRoleArn, "Execution role ARN should not be empty")
 	s.Contains(executionRoleArn, s.testPrefix+"-execution-role-without-path", "Execution role ARN should contain the expected role name")
@@ -92,19 +70,4 @@ func (s *ECSFargateSuite) TestRoleParsingWithoutPath() {
 	execRoleArnParts := strings.Split(executionRoleArn, "/")
 	s.Equal(2, len(execRoleArnParts), "Execution role ARN without path should have exactly 2 parts when split by '/'")
 	s.Contains(execRoleArnParts[1], s.testPrefix+"-execution-role-without-path", "Execution role name should be the second part after splitting by '/'")
-
-	// Test that containers are properly configured
-	s.GreaterOrEqual(len(containers), 2, "Expected at least 2 containers (datadog-agent + test-app)")
-
-	// Test Agent Container exists and is configured
-	agentContainer, found := GetContainer(containers, "datadog-agent")
-	s.True(found, "Container datadog-agent not found in definitions")
-	s.NotNil(agentContainer.Image, "Agent container image should not be nil")
-
-	// Test application container exists
-	appContainer, found := GetContainer(containers, "test-app")
-	s.True(found, "Container test-app not found in definitions")
-	s.Equal("nginx:latest", *appContainer.Image, "Unexpected image for test-app")
-
-	log.Println("TestRoleParsingWithoutPath: Role parsing without path test completed successfully")
 }

--- a/tests/role_parsing_test.go
+++ b/tests/role_parsing_test.go
@@ -31,12 +31,12 @@ func (s *ECSFargateSuite) TestRoleParsingWithPath() {
 
 	taskRoleArn := task["task_role_arn"]
 	s.NotEmpty(taskRoleArn, "Task role ARN should not be empty")
-	s.Contains(taskRoleArn, "/test-task-path/", "Task role ARN should contain the path '/test-path/'")
+	s.Contains(taskRoleArn, "/terraform-test/", "Task role ARN should contain the path '/test-path/'")
 	s.Contains(taskRoleArn, s.testPrefix+"-task-role-with-path", "Task role ARN should contain the expected role name")
 
 	executionRoleArn := task["execution_role_arn"]
 	s.NotEmpty(executionRoleArn, "Execution role ARN should not be empty")
-	s.Contains(executionRoleArn, "/test-execution-path/", "Execution role ARN should contain the path '/test-execution-path/'")
+	s.Contains(executionRoleArn, "/terraform-test/", "Execution role ARN should contain the path '/terraform-test/'")
 	s.Contains(executionRoleArn, s.testPrefix+"-execution-role-with-path", "Execution role ARN should contain the expected role name")
 }
 


### PR DESCRIPTION
### What does this PR do?

PR https://github.com/DataDog/terraform-aws-ecs-datadog/pull/40 fixed role arn name parsing to account for a role's `path`. This PR adds unit tests to validate that change/

### Motivation

Improve test coverage for edge cases like the one identified in the merged PR.

### Describe how you validated your changes

- [x] CI is green 🟢 

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Possible drawbacks and tradeoffs.
* Include info about alternatives that were considered and why the proposed version was chosen.
-->
