### PR TITLE
chore: Bump module version for 1.0.5 release

### DIFF
--- a/modules/ecs_fargate/datadog.tf
+++ b/modules/ecs_fargate/datadog.tf
@@ -6,7 +6,7 @@
 # Version and Install Info
 locals {
   # Datadog ECS task tags
-  version = "1.0.4"
+  version = "1.0.5"
 
   install_info_tool              = "terraform"
   install_info_tool_version      = "terraform-aws-ecs-datadog"


### PR DESCRIPTION
### What does this PR do?
<!--
A brief description of the change being made with this pull request.
-->

Bumps module version for 1.0.5 Datadog ECS Fargate Terraform module release.

