### PR TITLE
chore: Remove Race Condition Between Policy Attachments

### DIFF
--- a/modules/ecs_fargate/README.md
+++ b/modules/ecs_fargate/README.md
@@ -227,7 +227,6 @@ No modules.
 | [aws_iam_role_policy_attachment.existing_role_dd_secret](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.existing_role_ecs_task_permissions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.new_ecs_task_execution_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.new_role_dd_secret](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.new_role_ecs_task_permissions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_policy_document.dd_ecs_task_permissions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.dd_secret_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |


### PR DESCRIPTION
### What does this PR do?
<!--
A brief description of the change being made with this pull request.
-->

Removes race condition between policy attachments in the AWS API.

### Motivation
<!--
What inspired you to submit this pull request?
-->

Previously, the module attaches IAM policies to the same ECS task role using separate `aws_iam_role_policy_attachment` resources. When multiple policies are attached in parallel, AWS IAM does not support concurrent modifications to the same role, causing intermittent failures during Terraform apply.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* The PR description contains details of how you validated your changes.
-->

`terraform apply` on smoke_tests and check that IAM roles are properly created.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Possible drawbacks and tradeoffs.
* Include info about alternatives that were considered and why the proposed version was chosen.
-->
