### PR TITLE
chore: Release 1.1.0 - promote from beta to stable

### DIFF
--- a/modules/ecs_ec2/README.md
+++ b/modules/ecs_ec2/README.md
@@ -1,8 +1,5 @@
 # ECS on EC2 Module for Datadog Agent
 
-> **Technical Preview**: This module is in technical preview. While it is functional, we recommend validating it in your environment before widespread use.
-> If you encounter any issues, please open a GitHub issue to let us know.
-
 This Terraform module deploys the Datadog Agent as a **daemon service** on Amazon ECS clusters running on EC2 instances. The daemon scheduling strategy ensures that one Datadog Agent runs on each EC2 instance in your cluster, providing comprehensive monitoring for all containers on that instance.
 
 ## Key Features

--- a/modules/ecs_ec2/datadog.tf
+++ b/modules/ecs_ec2/datadog.tf
@@ -35,7 +35,7 @@ locals {
 # Version and Install Info
 locals {
   # Datadog ECS task tags
-  version = "1.1.0-beta"
+  version = "1.1.0"
 
   install_info_tool              = "terraform"
   install_info_tool_version      = "terraform-aws-ecs-datadog"

--- a/modules/ecs_fargate/datadog.tf
+++ b/modules/ecs_fargate/datadog.tf
@@ -6,7 +6,7 @@
 # Version and Install Info
 locals {
   # Datadog ECS task tags
-  version = "1.1.0-beta"
+  version = "1.1.0"
 
   install_info_tool              = "terraform"
   install_info_tool_version      = "terraform-aws-ecs-datadog"


### PR DESCRIPTION
## Summary

- Bumps version from `1.1.0-beta` to `1.1.0` in both ECS EC2 and ECS Fargate modules
- Removes the "Technical Preview" notice from the ECS EC2 module README now that it's GA