### PR TITLE
[CONTP-2016] Fix Fargate read-only filesystem settings

### DIFF
--- a/modules/ecs_fargate/datadog.tf
+++ b/modules/ecs_fargate/datadog.tf
@@ -442,7 +442,7 @@ locals {
         name                   = "datadog-log-router"
         image                  = "${var.dd_log_collection.fluentbit_config.registry}:${var.dd_log_collection.fluentbit_config.image_version}"
         essential              = var.dd_log_collection.fluentbit_config.is_log_router_essential
-        readonlyRootFilesystem = true
+        readonlyRootFilesystem = var.dd_readonly_root_filesystem
         firelensConfiguration = {
           type = "fluentbit"
           options = merge(

--- a/modules/ecs_fargate/datadog.tf
+++ b/modules/ecs_fargate/datadog.tf
@@ -372,7 +372,7 @@ locals {
         name                   = "init-volume"
         image                  = "${var.dd_registry}:${var.dd_image_version}"
         essential              = false
-        readOnlyRootFilesystem = true
+        readonlyRootFilesystem = true
         command                = ["/bin/sh", "-c", "cp -vnR /etc/datadog-agent/* /agent-config/ && exit 0"]
         mountPoints = [
           {
@@ -439,9 +439,10 @@ locals {
   dd_log_container = local.is_fluentbit_supported ? [
     merge(
       {
-        name      = "datadog-log-router"
-        image     = "${var.dd_log_collection.fluentbit_config.registry}:${var.dd_log_collection.fluentbit_config.image_version}"
-        essential = var.dd_log_collection.fluentbit_config.is_log_router_essential
+        name                   = "datadog-log-router"
+        image                  = "${var.dd_log_collection.fluentbit_config.registry}:${var.dd_log_collection.fluentbit_config.image_version}"
+        essential              = var.dd_log_collection.fluentbit_config.is_log_router_essential
+        readonlyRootFilesystem = true
         firelensConfiguration = {
           type = "fluentbit"
           options = merge(

--- a/tests/all_dd_inputs_test.go
+++ b/tests/all_dd_inputs_test.go
@@ -29,6 +29,7 @@ func (s *ECSFargateSuite) TestAllDDInputs() {
 
 	initContainer, found := GetContainer(containers, "init-volume")
 	s.True(found, "Container init-volume not found in definitions")
+	s.True(*initContainer.ReadonlyRootFilesystem, "init-volume should have a read-only root filesystem")
 	AssertMountPoint(s.T(), initContainer, MountInitVolume)
 
 	// Test Agent Container
@@ -86,6 +87,7 @@ func (s *ECSFargateSuite) TestAllDDInputs() {
 	s.True(found, "Container datadog-log-router not found in definitions")
 	s.Equal("public.ecr.aws/aws-observability/aws-for-fluent-bit:stable", *logRouterContainer.Image)
 	s.False(*logRouterContainer.Essential, "datadog-log-router should not be essential")
+	s.True(*logRouterContainer.ReadonlyRootFilesystem, "datadog-log-router should have a read-only root filesystem")
 	s.Equal("0", *logRouterContainer.User, "Unexpected user for datadog-log-router")
 	s.Equal(types.FirelensConfigurationTypeFluentbit, logRouterContainer.FirelensConfiguration.Type, "Unexpected firelens type")
 	s.Equal("true", logRouterContainer.FirelensConfiguration.Options["enable-ecs-log-metadata"], "Unexpected firelens option value")

--- a/tests/logging_only_test.go
+++ b/tests/logging_only_test.go
@@ -81,6 +81,7 @@ func (s *ECSFargateSuite) TestLoggingOnly() {
 	s.Equal("public.ecr.aws/aws-observability/aws-for-fluent-bit:stable", *logRouterContainer.Image,
 		"Unexpected image for log router")
 	s.False(*logRouterContainer.Essential, "Log router should not be essential")
+	s.True(*logRouterContainer.ReadonlyRootFilesystem, "Log router should have a read-only root filesystem")
 	s.Equal("0", *logRouterContainer.User, "Log router should run as root user")
 
 	// Verify log router environment variables

--- a/tests/logging_only_test.go
+++ b/tests/logging_only_test.go
@@ -81,7 +81,7 @@ func (s *ECSFargateSuite) TestLoggingOnly() {
 	s.Equal("public.ecr.aws/aws-observability/aws-for-fluent-bit:stable", *logRouterContainer.Image,
 		"Unexpected image for log router")
 	s.False(*logRouterContainer.Essential, "Log router should not be essential")
-	s.True(*logRouterContainer.ReadonlyRootFilesystem, "Log router should have a read-only root filesystem")
+	s.False(*logRouterContainer.ReadonlyRootFilesystem, "Log router should have a writable root filesystem")
 	s.Equal("0", *logRouterContainer.User, "Log router should run as root user")
 
 	// Verify log router environment variables


### PR DESCRIPTION
### What does this PR do?

Corrects the ECS property casing for the read-only init container and enables a read-only root filesystem for the Fluent Bit log router. Adds regression assertions for both generated container definitions.

### Motivation

Ensure ECS recognizes and applies the intended read-only root filesystem settings.

### Describe how you validated your changes

- `terraform fmt -check -recursive .`
- `terraform -chdir=modules/ecs_fargate validate`
- `go test ./tests -run '^$'`
- `git diff --check`
